### PR TITLE
Switch to nitrogen-project-mm repos

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -6,7 +6,7 @@
 	<default revision="refs/tags/android-6.0.1_r60" remote="aosp" sync-j="16" />
 
 	<remote name="nos"
-		fetch="https://github.com/nitrogen-project"
+		fetch="https://github.com/nitrogen-project-mm"
 		sync-j="16"/>
 
 	<!--


### PR DESCRIPTION
You can't sync mm6.0 repos from nitrogen-project, we have to switch to nitrogen-project-mm repos.
